### PR TITLE
Control background processes with Supervisor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,18 @@ RUN mkdir -p $GRAKN_HOME && \
     curl -sSL https://github.com/graknlabs/grakn/releases/download/v${GRAKN_VERSION}/grakn-dist-${GRAKN_VERSION}.tar.gz | \
     tar -C $GRAKN_HOME --strip-components=1 -xzv
 
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends supervisor gdb && \
+    mkdir -p /var/log/supervisor && \
+    rm -rf /var/lib/apt/lists/*
+
 ENV PATH=$PATH:$GRAKN_HOME
 WORKDIR $GRAKN_HOME
 
 COPY cassandra.yaml $GRAKN_HOME/services/cassandra
-COPY docker-entrypoint /usr/local/bin
+COPY grakn-run /usr/local/bin
+COPY supervisord.conf /etc/supervisord.conf
 
 # Grakn Server
 EXPOSE 4567
@@ -28,4 +35,4 @@ EXPOSE 9160
 # Grakn gRPC
 EXPOSE 48555
 
-ENTRYPOINT [ "docker-entrypoint" ]
+CMD ["/usr/bin/supervisord"]

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-grakn server start
-tail -f -n +1 $GRAKN_HOME/logs/grakn.log

--- a/grakn-run
+++ b/grakn-run
@@ -1,0 +1,3 @@
+#!/bin/sh
+grakn server start $1
+exec gdb -p `cat /tmp/grakn-$1.pid`

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,24 @@
+[supervisord]
+nodaemon=true
+logfile=/var/log/supervisor/supervisord.log
+pidfile=/var/run/supervisord.pid
+
+[inet_http_server]
+port=127.0.0.1:9001
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+
+[program:engine]
+command=/usr/bin/pidproxy /tmp/grakn-engine.pid /usr/local/bin/grakn-run engine
+stopasgroup=true
+
+[program:queue]
+command=/usr/bin/pidproxy /tmp/grakn-queue.pid /usr/local/bin/grakn-run queue
+stopasgroup=true
+
+[program:storage]
+command=/usr/bin/pidproxy /tmp/grakn-storage.pid /usr/local/bin/grakn-run storage
+stopasgroup=true


### PR DESCRIPTION
Allow restarting the container. Some workarounds were needed (attach to the background processes with gdb) but seem to work nicely.